### PR TITLE
Fix undefined error in cordova 5.0 exec function

### DIFF
--- a/www/Fullscreen.js
+++ b/www/Fullscreen.js
@@ -6,11 +6,11 @@ var exec = require('cordova/exec');
 module.exports = {
     /* On */
     on: function(successCallback, errorCallback) {
-        exec(successCallback, errorCallback, 'Fullscreen', 'on');
+        exec(successCallback, errorCallback, 'Fullscreen', 'on', []);
     },
     
     /* Off */
     off: function(successCallback, errorCallback) {
-        exec(successCallback, errorCallback, 'Fullscreen', 'off');
+        exec(successCallback, errorCallback, 'Fullscreen', 'off', []);
     },
 };


### PR DESCRIPTION
The exec function expects an array of optional args, apparently if it is omitted cordova will throw an "Cannot read property length of 'undefined'" error.

Adding an empty array fixes this and the code now works as intended.